### PR TITLE
Allocate a large enough `label` to avoid memory overflow

### DIFF
--- a/Programs/elec_interp.c
+++ b/Programs/elec_interp.c
@@ -62,7 +62,7 @@ void initialize_interp_arrays()
 
   float xHI,xHeI,xHeII,z,T;
   float trash;
-  char label[] = " ";
+  char label[64];
 
   int i;
   int n_ion;


### PR DESCRIPTION
It's entirely possible that this overflow will have had no effect on the
code (on my test machine `xHI` is in the next memory address and it gets
overwritten in the subsequent statement), however, that is not
guaranteed.