### PR TITLE
Modify driver to avoid error

### DIFF
--- a/Programs/drive_zscroll_noTs.c
+++ b/Programs/drive_zscroll_noTs.c
@@ -150,18 +150,18 @@ int main(int argc, char ** argv){
       if (USE_HALO_FIELD)
 	// New in v1.4: These filenames are just a stopgap to avoid error. I have to modify this part using proper parameters.
 	//sprintf(cmnd, "./delta_T %06.2f ../Boxes/xH_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, EFF_FACTOR_PL_INDEX, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
-	sprintf(cmnd, "./delta_T %06.2f ../Boxes/xH_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, HII_EFF_FACTOR, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
+	sprintf(cmnd, "./delta_T %06.2f ../Boxes/xH_z%06.2f_nf*_%i_%.0fMpc", Z, Z, HII_DIM, BOX_LEN);
       else
 	//sprintf(cmnd, "./delta_T %06.2f ../Boxes/xH_nohalos_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, EFF_FACTOR_PL_INDEX, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
-	sprintf(cmnd, "./delta_T %06.2f ../Boxes/xH_nohalos_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, HII_EFF_FACTOR, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
+	sprintf(cmnd, "./delta_T %06.2f ../Boxes/xH_nohalos_z%06.2f_nf*_%i_%.0fMpc", Z, Z, HII_DIM, BOX_LEN);
       break;
     default:
       if (USE_HALO_FIELD)
 	//sprintf(cmnd, "./delta_T %06.2f ../Boxes/sphere_xH_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, EFF_FACTOR_PL_INDEX, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
-	sprintf(cmnd, "./delta_T %06.2f ../Boxes/sphere_xH_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, HII_EFF_FACTOR, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
+	sprintf(cmnd, "./delta_T %06.2f ../Boxes/sphere_xH_z%06.2f_nf*_%i_%.0fMpc", Z, Z, HII_DIM, BOX_LEN);
       else
 	//sprintf(cmnd, "./delta_T %06.2f ../Boxes/sphere_xH_nohalos_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, EFF_FACTOR_PL_INDEX, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
-	sprintf(cmnd, "./delta_T %06.2f ../Boxes/sphere_xH_nohalos_z%06.2f_nf*_eff%.1f_effPLindex%.1f_HIIfilter%i_Mmin%.1e_RHIImax%.0f_%i_%.0fMpc", Z, Z,HII_EFF_FACTOR, HII_EFF_FACTOR, HII_FILTER, M_MIN, R_BUBBLE_MAX, HII_DIM, BOX_LEN);
+	sprintf(cmnd, "./delta_T %06.2f ../Boxes/sphere_xH_nohalos_z%06.2f_nf*_%i_%.0fMpc", Z, Z, HII_DIM, BOX_LEN);
     }
     time(&curr_time);
     fprintf(stderr, "Now calling: %s, %g min have ellapsed\n", cmnd, difftime(start_time, curr_time)/60.0);


### PR DESCRIPTION
The filenames used in 'drive_zscroll_noTs.c' to do temperature map can't match with those of xH_z files generated by 'find_HII_bubbles' leading to error when calling 'delta_T', and thus the temperature map isn't generated.